### PR TITLE
Fix comment typo in proxy util

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -58,7 +58,7 @@ export async function specificProxyRequest(
   const method = opts.fetchOptions?.method || event.method;
   const oldHeaders = getProxyRequestHeaders(event);
 
-  // netlify seems to be changing the content-encoding header to gzip when the reponse is encoded in zstd
+  // netlify seems to be changing the content-encoding header to gzip when the response is encoded in zstd
   // so as temp fix just not sending zstd in accept encoding
   if (oldHeaders['accept-encoding']?.includes('zstd'))
     oldHeaders['accept-encoding'] = oldHeaders['accept-encoding']


### PR DESCRIPTION
## Summary
- correct a misspelling in the Netlify proxy comment

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68409222ea3c83249d77ab8b64806cb6